### PR TITLE
Fix bugs in Z2 and expose 'contains' bool

### DIFF
--- a/api/src/main/scala/org/locationtech/sfcurve/SpaceFillingCurve2D.scala
+++ b/api/src/main/scala/org/locationtech/sfcurve/SpaceFillingCurve2D.scala
@@ -10,7 +10,7 @@ package org.locationtech.sfcurve
 
 class RangeComputeHints extends java.util.HashMap[String, AnyRef]
 
-trait IndexRange {
+sealed trait IndexRange {
   def lower: Long
   def upper: Long
   def contained: Boolean

--- a/api/src/main/scala/org/locationtech/sfcurve/SpaceFillingCurve2D.scala
+++ b/api/src/main/scala/org/locationtech/sfcurve/SpaceFillingCurve2D.scala
@@ -36,11 +36,11 @@ object IndexRange {
     }
   }
 
+  implicit object IndexRangeIsOrdered extends IndexRangeOrdering
+
   def apply(l: Long, u: Long, contained: Boolean): IndexRange =
     if(contained) CoveredRange(l, u)
     else          OverlappingRange(l, u)
-
-  implicit object IndexRangeIsOrdered extends IndexRangeOrdering
 }
 
 trait SpaceFillingCurve2D {

--- a/api/src/main/scala/org/locationtech/sfcurve/SpaceFillingCurve2D.scala
+++ b/api/src/main/scala/org/locationtech/sfcurve/SpaceFillingCurve2D.scala
@@ -8,8 +8,10 @@
 
 package org.locationtech.sfcurve
 
+class RangeComputeHints extends java.util.HashMap[String, AnyRef]
+
 trait SpaceFillingCurve2D {
   def toIndex(x: Double, y: Double): Long
   def toPoint(i: Long): (Double, Double)
-  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, maxRecurse: Int): Seq[(Long, Long, Boolean)]
+  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, hints: Option[RangeComputeHints] = None): Seq[(Long, Long, Boolean)]
 }

--- a/api/src/main/scala/org/locationtech/sfcurve/SpaceFillingCurve2D.scala
+++ b/api/src/main/scala/org/locationtech/sfcurve/SpaceFillingCurve2D.scala
@@ -10,8 +10,41 @@ package org.locationtech.sfcurve
 
 class RangeComputeHints extends java.util.HashMap[String, AnyRef]
 
+trait IndexRange {
+  def lower: Long
+  def upper: Long
+  def contained: Boolean
+  def tuple = (lower, upper, contained)
+}
+
+case class CoveredRange(lower: Long, upper: Long) extends IndexRange {
+  val contained = true
+}
+
+case class OverlappingRange(lower: Long, upper: Long) extends IndexRange {
+  val contained = false
+}
+
+object IndexRange {
+  trait IndexRangeOrdering extends Ordering[IndexRange] {
+    override def compare(x: IndexRange, y: IndexRange): Int = {
+      val c1 = x.lower.compareTo(y.lower)
+      if(c1 != 0) return c1
+      val c2 = x.upper.compareTo(y.upper)
+      if(c2 != 0) return c2
+      0
+    }
+  }
+
+  def apply(l: Long, u: Long, contained: Boolean): IndexRange =
+    if(contained) CoveredRange(l, u)
+    else          OverlappingRange(l, u)
+
+  implicit object IndexRangeIsOrdered extends IndexRangeOrdering
+}
+
 trait SpaceFillingCurve2D {
   def toIndex(x: Double, y: Double): Long
   def toPoint(i: Long): (Double, Double)
-  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, hints: Option[RangeComputeHints] = None): Seq[(Long, Long, Boolean)]
+  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, hints: Option[RangeComputeHints] = None): Seq[IndexRange]
 }

--- a/api/src/main/scala/org/locationtech/sfcurve/SpaceFillingCurve2D.scala
+++ b/api/src/main/scala/org/locationtech/sfcurve/SpaceFillingCurve2D.scala
@@ -11,5 +11,5 @@ package org.locationtech.sfcurve
 trait SpaceFillingCurve2D {
   def toIndex(x: Double, y: Double): Long
   def toPoint(i: Long): (Double, Double)
-  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double): Seq[(Long, Long)]
+  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, maxRecurse: Int): Seq[(Long, Long, Boolean)]
 }

--- a/hilbert/src/main/scala/org/locationtech/sfcurve/hilbert/HilbertCurve2D.scala
+++ b/hilbert/src/main/scala/org/locationtech/sfcurve/hilbert/HilbertCurve2D.scala
@@ -88,7 +88,7 @@ class HilbertCurve2D(resolution: Int) extends SpaceFillingCurve2D {
     (x, y)
   }
 
-  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, maxRecurse: Int = -1 /* not used */): Seq[(Long, Long, Boolean)] = {
+  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, hints: Option[RangeComputeHints] = None): Seq[(Long, Long, Boolean)] = {
     val chc = new CompactHilbertCurve(Array[Int](resolution, resolution))
     val region = new java.util.ArrayList[LongRange]()
 
@@ -133,9 +133,7 @@ class HilbertCurve2D(resolution: Int) extends SpaceFillingCurve2D {
       val range = l.getIndexRange
       val start = range.getStart.asInstanceOf[Long]
       val end   = range.getEnd.asInstanceOf[Long]
-      val (rlx, rly) = toPoint(start)
-      val (rux, ruy) = toPoint(end)
-      val contained = rlx >= xmin && rux <= xmax && rly >= ymin && ruy <= ymax
+      val contained = l.isPotentialOverSelectivity
       result = (start, end, contained) :: result
     }
     result

--- a/hilbert/src/main/scala/org/locationtech/sfcurve/hilbert/HilbertCurve2D.scala
+++ b/hilbert/src/main/scala/org/locationtech/sfcurve/hilbert/HilbertCurve2D.scala
@@ -88,7 +88,7 @@ class HilbertCurve2D(resolution: Int) extends SpaceFillingCurve2D {
     (x, y)
   }
 
-  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, hints: Option[RangeComputeHints] = None): Seq[(Long, Long, Boolean)] = {
+  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, hints: Option[RangeComputeHints] = None): Seq[IndexRange] = {
     val chc = new CompactHilbertCurve(Array[Int](resolution, resolution))
     val region = new java.util.ArrayList[LongRange]()
 
@@ -125,7 +125,7 @@ class HilbertCurve2D(resolution: Int) extends SpaceFillingCurve2D {
     val ranges = query.getFilteredIndexRanges
 
     //result
-    var result = List[(Long,Long, Boolean)]()
+    var result = List[IndexRange]()
     val itr = ranges.iterator
 
     while(itr.hasNext) {
@@ -134,7 +134,7 @@ class HilbertCurve2D(resolution: Int) extends SpaceFillingCurve2D {
       val start = range.getStart.asInstanceOf[Long]
       val end   = range.getEnd.asInstanceOf[Long]
       val contained = l.isPotentialOverSelectivity
-      result = (start, end, contained) :: result
+      result = IndexRange(start, end, contained) :: result
     }
     result
   }

--- a/hilbert/src/main/scala/org/locationtech/sfcurve/hilbert/HilbertCurve2D.scala
+++ b/hilbert/src/main/scala/org/locationtech/sfcurve/hilbert/HilbertCurve2D.scala
@@ -88,7 +88,7 @@ class HilbertCurve2D(resolution: Int) extends SpaceFillingCurve2D {
     (x, y)
   }
 
-  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double): Seq[(Long, Long)] = {
+  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, maxRecurse: Int = -1 /* not used */): Seq[(Long, Long, Boolean)] = {
     val min = (xmin, ymin)
     val max = (xmax, ymax)
 
@@ -129,15 +129,14 @@ class HilbertCurve2D(resolution: Int) extends SpaceFillingCurve2D {
     var ranges: java.util.List[FilteredIndexRange[LongRange, LongRange]] = query.getFilteredIndexRanges()
 
     //result
-    var result = List[(Long,Long)]()
+    var result = List[(Long,Long, Boolean)]()
     val itr = ranges.iterator
 
-    while(itr.hasNext()) {
-       var l = itr.next()
-       result = (
-                 l.getIndexRange().getStart().asInstanceOf[Long], 
-                 l.getIndexRange().getEnd().asInstanceOf[Long]
-                ) :: result
+    while(itr.hasNext) {
+      val l = itr.next()
+      val start = l.getIndexRange.getStart.asInstanceOf[Long]
+      val end   = l.getIndexRange.getEnd.asInstanceOf[Long]
+      result = (start, end, false) :: result
     }
     result
   }

--- a/hilbert/src/test/scala/org/locationtech/sfcurve/hilbert/HilbertCurveSpec.scala
+++ b/hilbert/src/test/scala/org/locationtech/sfcurve/hilbert/HilbertCurveSpec.scala
@@ -45,6 +45,10 @@ class HilbertCurveSpec extends FunSpec with Matchers {
       val range = sfc.toRanges(-178.123456, -86.398493, 179.3211113, 87.393483)
 
       range should have length 3
+
+      // the last range is not wh
+      val (_, _, lastcontains) = range(2)
+      lastcontains should be(false)
     }
 
     it("Takes a Long value to a Point (Double, Double)"){

--- a/hilbert/src/test/scala/org/locationtech/sfcurve/hilbert/HilbertCurveSpec.scala
+++ b/hilbert/src/test/scala/org/locationtech/sfcurve/hilbert/HilbertCurveSpec.scala
@@ -30,8 +30,8 @@ class HilbertCurveSpec extends FunSpec with Matchers {
       val sfc = new HilbertCurve2D(resolution)
       val index: Long = sfc.toIndex(0.0, 0.0)
 
-      val xEpsilon = (360.0 / gridCells)
-      val yEpsilon = (180.0 / gridCells)
+      val xEpsilon = 360.0 / gridCells
+      val yEpsilon = 180.0 / gridCells
 
       val point = sfc.toPoint(index)
 
@@ -47,7 +47,7 @@ class HilbertCurveSpec extends FunSpec with Matchers {
       range should have length 3
 
       // the last range is not wh
-      val (_, _, lastcontains) = range(2)
+      val (_, _, lastcontains) = range(2).tuple
       lastcontains should be(false)
     }
 

--- a/hilbert/src/test/scala/org/locationtech/sfcurve/hilbert/HilbertCurveSpec.scala
+++ b/hilbert/src/test/scala/org/locationtech/sfcurve/hilbert/HilbertCurveSpec.scala
@@ -46,7 +46,7 @@ class HilbertCurveSpec extends FunSpec with Matchers {
 
       range should have length 3
 
-      // the last range is not wh
+      // the last range is not wholly contained within the query region
       val (_, _, lastcontains) = range(2).tuple
       lastcontains should be(false)
     }

--- a/zorder/src/main/scala/org/locationtech/sfcurve/zorder/MergeQueue.scala
+++ b/zorder/src/main/scala/org/locationtech/sfcurve/zorder/MergeQueue.scala
@@ -9,7 +9,7 @@
 package org.locationtech.sfcurve.zorder
 
 class MergeQueue(initialSize: Int = 1) {
-  private var array = if(initialSize <= 1) { Array.ofDim[(Long, Long)](1) } else { Array.ofDim[(Long, Long)](initialSize) }
+  private var array = if(initialSize <= 1) { Array.ofDim[(Long, Long, Boolean)](1) } else { Array.ofDim[(Long, Long, Boolean)](initialSize) }
   private var _size = 0
  
   def size = _size
@@ -23,7 +23,7 @@ class MergeQueue(initialSize: Int = 1) {
     _size = _size - 1
   }
  
-  private def insertElement(range: (Long, Long), i: Int): Unit = {
+  private def insertElement(range: (Long, Long, Boolean), i: Int): Unit = {
     ensureSize(_size + 1)
     if(i == _size) {
       array(i) = range
@@ -50,32 +50,31 @@ class MergeQueue(initialSize: Int = 1) {
       // Clamp newSize to Int.MaxValue
       if (newSize > Int.MaxValue) newSize = Int.MaxValue
  
-      val newArray: Array[(Long, Long)] = new Array(newSize.toInt)
+      val newArray: Array[(Long, Long, Boolean)] = new Array(newSize.toInt)
       scala.compat.Platform.arraycopy(array, 0, newArray, 0, _size)
       array = newArray
     }
   }
  
-  val ordering = implicitly[Ordering[(Long, Long)]]
+  val ordering = implicitly[Ordering[(Long, Long, Boolean)]]
  
   /** Inserts a single range into the priority queue.
    *
    *  @param  range        the element to insert.
    */
-  @annotation.tailrec
-  final def +=(range: (Long, Long)): Unit = {
+  final def +=(range: (Long, Long, Boolean)): Unit = {
     val res = if(_size == 0) { -1 } else { java.util.Arrays.binarySearch(array, 0, _size, range, ordering) }
     if(res < 0) {
       val i = -(res + 1)
-      var (thisStart, thisEnd) = range
+      var (thisStart, thisEnd, b) = range
       var removeLeft = false
  
       var removeRight = false
-      var rightRemainder: Option[(Long, Long)] = None
+      var rightRemainder: Option[(Long, Long, Boolean)] = None
  
       // Look at the left range
       if(i != 0) {
-        val (prevStart, prevEnd) = array(i - 1)
+        val (prevStart, prevEnd, b) = array(i - 1)
         if(prevStart == thisStart) {
           removeLeft = true
         }
@@ -90,7 +89,7 @@ class MergeQueue(initialSize: Int = 1) {
  
       // Look at the right range
       if(i < _size  && _size > 0) {
-        val (nextStart, nextEnd) = array(i)
+        val (nextStart, nextEnd, b) = array(i)
         if(thisStart == nextStart) {
           removeRight = true
           thisEnd = nextEnd
@@ -100,7 +99,7 @@ class MergeQueue(initialSize: Int = 1) {
             if(nextEnd - 1 >= thisEnd) {
               thisEnd = nextEnd
             } else if (nextEnd < thisEnd - 1) {
-              rightRemainder = Some((nextEnd + 1, thisEnd))
+              rightRemainder = Some((nextEnd + 1, thisEnd, b))
               thisEnd = nextEnd
             }
           }
@@ -109,13 +108,13 @@ class MergeQueue(initialSize: Int = 1) {
  
       if(removeRight) { 
         if(!removeLeft) {
-          array(i) = (thisStart, thisEnd)
+          array(i) = (thisStart, thisEnd, b)
         } else {
-          array(i-1) = (thisStart, thisEnd)
+          array(i-1) = (thisStart, thisEnd, b)
           removeElement(i)
         }
       } else if(removeLeft) {
-        array(i-1) = (thisStart, thisEnd)
+        array(i-1) = (thisStart, thisEnd, b)
       } else {
         insertElement(range, i)
       }
@@ -127,8 +126,8 @@ class MergeQueue(initialSize: Int = 1) {
     }
   }
  
-  def toSeq: Seq[(Long, Long)] = {
-    val result = Array.ofDim[(Long, Long)](size)
+  def toSeq: Seq[(Long, Long, Boolean)] = {
+    val result = Array.ofDim[(Long, Long, Boolean)](size)
     System.arraycopy(array, 0, result, 0, size)
     result
   }

--- a/zorder/src/main/scala/org/locationtech/sfcurve/zorder/MergeQueue.scala
+++ b/zorder/src/main/scala/org/locationtech/sfcurve/zorder/MergeQueue.scala
@@ -8,8 +8,10 @@
 
 package org.locationtech.sfcurve.zorder
 
+import org.locationtech.sfcurve.IndexRange
+
 class MergeQueue(initialSize: Int = 1) {
-  private var array = if(initialSize <= 1) { Array.ofDim[(Long, Long, Boolean)](1) } else { Array.ofDim[(Long, Long, Boolean)](initialSize) }
+  private var array = if(initialSize <= 1) { Array.ofDim[IndexRange](1) } else { Array.ofDim[IndexRange](initialSize) }
   private var _size = 0
  
   def size = _size
@@ -23,7 +25,7 @@ class MergeQueue(initialSize: Int = 1) {
     _size = _size - 1
   }
  
-  private def insertElement(range: (Long, Long, Boolean), i: Int): Unit = {
+  private def insertElement(range: IndexRange, i: Int): Unit = {
     ensureSize(_size + 1)
     if(i == _size) {
       array(i) = range
@@ -50,35 +52,37 @@ class MergeQueue(initialSize: Int = 1) {
       // Clamp newSize to Int.MaxValue
       if (newSize > Int.MaxValue) newSize = Int.MaxValue
  
-      val newArray: Array[(Long, Long, Boolean)] = new Array(newSize.toInt)
+      val newArray: Array[IndexRange] = new Array(newSize.toInt)
       scala.compat.Platform.arraycopy(array, 0, newArray, 0, _size)
       array = newArray
     }
   }
- 
-  val ordering = implicitly[Ordering[(Long, Long, Boolean)]]
+
+  val ordering = IndexRange.IndexRangeIsOrdered
  
   /** Inserts a single range into the priority queue.
    *
    *  @param  range        the element to insert.
    */
-  final def +=(range: (Long, Long, Boolean)): Unit = {
+  final def +=(range: IndexRange): Unit = {
     val res = if(_size == 0) { -1 } else { java.util.Arrays.binarySearch(array, 0, _size, range, ordering) }
     if(res < 0) {
       val i = -(res + 1)
-      var (thisStart, thisEnd, b) = range
+      var (thisStart, thisEnd, contained) = range.tuple
       var removeLeft = false
  
       var removeRight = false
-      var rightRemainder: Option[(Long, Long, Boolean)] = None
+      var rightRemainder: Option[IndexRange] = None
  
       // Look at the left range
       if(i != 0) {
-        val (prevStart, prevEnd, b) = array(i - 1)
+        val (prevStart, prevEnd, b) = array(i - 1).tuple
         if(prevStart == thisStart) {
+          contained = contained && b
           removeLeft = true
         }
-        if (prevEnd + 1 >= thisStart) { 
+        if (prevEnd + 1 >= thisStart) {
+          contained = contained && b
           removeLeft = true
           thisStart = prevStart
           if(prevEnd > thisEnd) {
@@ -89,17 +93,19 @@ class MergeQueue(initialSize: Int = 1) {
  
       // Look at the right range
       if(i < _size  && _size > 0) {
-        val (nextStart, nextEnd, b) = array(i)
+        val (nextStart, nextEnd, b) = array(i).tuple
         if(thisStart == nextStart) {
           removeRight = true
           thisEnd = nextEnd
+          contained = contained && b
         } else {
           if(thisEnd + 1 >= nextStart) {
             removeRight = true
+            contained = contained && b
             if(nextEnd - 1 >= thisEnd) {
               thisEnd = nextEnd
             } else if (nextEnd < thisEnd - 1) {
-              rightRemainder = Some((nextEnd + 1, thisEnd, b))
+              rightRemainder = Some(IndexRange(nextEnd + 1, thisEnd, contained && b))
               thisEnd = nextEnd
             }
           }
@@ -108,13 +114,13 @@ class MergeQueue(initialSize: Int = 1) {
  
       if(removeRight) { 
         if(!removeLeft) {
-          array(i) = (thisStart, thisEnd, b)
+          array(i) = IndexRange(thisStart, thisEnd, contained)
         } else {
-          array(i-1) = (thisStart, thisEnd, b)
+          array(i-1) = IndexRange(thisStart, thisEnd, contained)
           removeElement(i)
         }
       } else if(removeLeft) {
-        array(i-1) = (thisStart, thisEnd, b)
+        array(i-1) = IndexRange(thisStart, thisEnd, contained)
       } else {
         insertElement(range, i)
       }
@@ -126,8 +132,8 @@ class MergeQueue(initialSize: Int = 1) {
     }
   }
  
-  def toSeq: Seq[(Long, Long, Boolean)] = {
-    val result = Array.ofDim[(Long, Long, Boolean)](size)
+  def toSeq: Seq[IndexRange] = {
+    val result = Array.ofDim[IndexRange](size)
     System.arraycopy(array, 0, result, 0, size)
     result
   }

--- a/zorder/src/main/scala/org/locationtech/sfcurve/zorder/Z2.scala
+++ b/zorder/src/main/scala/org/locationtech/sfcurve/zorder/Z2.scala
@@ -8,6 +8,8 @@
 
 package org.locationtech.sfcurve.zorder
 
+import org.locationtech.sfcurve.IndexRange
+
 class Z2(val z: Long) extends AnyVal {
   import Z2._
 
@@ -105,7 +107,7 @@ object Z2 {
   }
 
   /** Recurse down the quad-tree and report all z-ranges which are contained in the rectangle defined by the min and max points */
-  def zranges(min: Z2, max: Z2, globalMaxRecurse: Int = 32): Seq[(Long, Long, Boolean)] = {
+  def zranges(min: Z2, max: Z2, globalMaxRecurse: Int = 32): Seq[IndexRange] = {
     val (commonPrefix, commonBits) = longestCommonPrefix(min.z, max.z)
 
     // base our recursion on the depth of the tree that we get 'for free' from the common prefix
@@ -126,7 +128,7 @@ object Z2 {
       val nextLevel = level - 1
       val qr = Z2Range(new Z2(min), new Z2(max))
       if (sr containsInUserSpace qr){                         // whole range matches, happy day
-        mq += (qr.min.z, qr.max.z, true)
+        mq += IndexRange(qr.min.z, qr.max.z, contained = true)
         reportCounter +=1
       } else if (sr overlapsInUserSpace qr) { // some portion of this range are excluded
         if(offset > 0 && level > 0) {
@@ -136,7 +138,7 @@ object Z2 {
           _zranges(min, offset - MAX_DIM, 3, nextLevel)
           //let our children punt on each subrange
         } else {
-          mq += (qr.min.z, qr.max.z, false)
+          mq += IndexRange(qr.min.z, qr.max.z, contained = false)
         }
       }
     }

--- a/zorder/src/main/scala/org/locationtech/sfcurve/zorder/Z2Range.scala
+++ b/zorder/src/main/scala/org/locationtech/sfcurve/zorder/Z2Range.scala
@@ -36,7 +36,24 @@ case class Z2Range(min: Z2, max: Z2){
     _overlaps(min.dim(0), max.dim(0), r.min.dim(0), r.max.dim(0)) &&
     _overlaps(min.dim(1), max.dim(1), r.min.dim(1), r.max.dim(1))
   }
-  
+
+  // contains in user space - each dimension is contained
+  def containsInUserSpace(bits: Z2) = {
+    val (x, y) = bits.decode
+    x >= min.d0 && x <= max.d0 && y >= min.d1 && y <= max.d1
+  }
+
+  // contains in user space - each dimension is contained
+  def containsInUserSpace(r: Z2Range): Boolean = containsInUserSpace(r.min) && containsInUserSpace(r.max)
+
+  // overlap in user space - if any dimension overlaps
+  def overlapsInUserSpace(r: Z2Range): Boolean =
+    overlaps(min.d0, max.d0, r.min.d0, r.max.d0) &&
+      overlaps(min.d1, max.d1, r.min.d1, r.max.d1)
+
+  private def overlaps(a1: Int, a2: Int, b1: Int, b2: Int) = math.max(a1, b1) <= math.min(a2, b2)
+
+
   /** 
    * Cuts Z-Range in two, can be used to perform augmented binary search
    * @param xd: division point

--- a/zorder/src/main/scala/org/locationtech/sfcurve/zorder/Z3.scala
+++ b/zorder/src/main/scala/org/locationtech/sfcurve/zorder/Z3.scala
@@ -7,6 +7,8 @@
 *************************************************************************/
 package org.locationtech.sfcurve.zorder
 
+import org.locationtech.sfcurve.IndexRange
+
 class Z3(val z: Long) extends AnyVal {
   import Z3._
 
@@ -108,7 +110,7 @@ object Z3 {
    * Recurse down the oct-tree and report all z-ranges which are contained
    * in the cube defined by the min and max points
    */
-  def zranges(min: Z3, max: Z3): Seq[(Long, Long, Boolean)] = {
+  def zranges(min: Z3, max: Z3): Seq[IndexRange] = {
     val (commonPrefix, commonBits) = longestCommonPrefix(min.z, max.z)
 
     // base our recursion on the depth of the tree that we get 'for free' from the common prefix
@@ -124,7 +126,7 @@ object Z3 {
 
       if (searchRange containsInUserSpace octRange) {
         // whole range matches, happy day
-        mq += (octRange.min.z, octRange.max.z, true)
+        mq += IndexRange(octRange.min.z, octRange.max.z, contained = true)
       } else if (searchRange overlapsInUserSpace octRange) {
         if (level < maxRecurse && offset > 0) {
           // some portion of this range is excluded
@@ -141,7 +143,7 @@ object Z3 {
           zranges(min, nextOffset, 7, nextLevel)
         } else {
           // bottom out - add the entire range so we don't miss anything
-          mq += (octRange.min.z, octRange.max.z, false)
+          mq += IndexRange(octRange.min.z, octRange.max.z, false)
         }
       }
     }

--- a/zorder/src/main/scala/org/locationtech/sfcurve/zorder/Z3.scala
+++ b/zorder/src/main/scala/org/locationtech/sfcurve/zorder/Z3.scala
@@ -108,7 +108,7 @@ object Z3 {
    * Recurse down the oct-tree and report all z-ranges which are contained
    * in the cube defined by the min and max points
    */
-  def zranges(min: Z3, max: Z3): Seq[(Long, Long)] = {
+  def zranges(min: Z3, max: Z3): Seq[(Long, Long, Boolean)] = {
     val (commonPrefix, commonBits) = longestCommonPrefix(min.z, max.z)
 
     // base our recursion on the depth of the tree that we get 'for free' from the common prefix
@@ -124,7 +124,7 @@ object Z3 {
 
       if (searchRange containsInUserSpace octRange) {
         // whole range matches, happy day
-        mq += (octRange.min.z, octRange.max.z)
+        mq += (octRange.min.z, octRange.max.z, true)
       } else if (searchRange overlapsInUserSpace octRange) {
         if (level < maxRecurse && offset > 0) {
           // some portion of this range is excluded
@@ -141,7 +141,7 @@ object Z3 {
           zranges(min, nextOffset, 7, nextLevel)
         } else {
           // bottom out - add the entire range so we don't miss anything
-          mq += (octRange.min.z, octRange.max.z)
+          mq += (octRange.min.z, octRange.max.z, false)
         }
       }
     }

--- a/zorder/src/main/scala/org/locationtech/sfcurve/zorder/ZCurve2D.scala
+++ b/zorder/src/main/scala/org/locationtech/sfcurve/zorder/ZCurve2D.scala
@@ -61,7 +61,7 @@ class ZCurve2D(resolution: Int) extends SpaceFillingCurve2D {
   def validateX(x: Double) = math.min(math.max(xmin, x), xmax)
   def validateY(y: Double) = math.min(math.max(ymin, y), ymax)
 
-  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, hints: Option[RangeComputeHints] = None): Seq[(Long, Long, Boolean)] = {
+  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, hints: Option[RangeComputeHints] = None): Seq[IndexRange] = {
     import ZCurve2D.DEFAULT_MAX_RECURSION
 
     import scala.collection.JavaConverters._

--- a/zorder/src/main/scala/org/locationtech/sfcurve/zorder/ZCurve2D.scala
+++ b/zorder/src/main/scala/org/locationtech/sfcurve/zorder/ZCurve2D.scala
@@ -25,16 +25,16 @@ class ZCurve2D(resolution: Int) extends SpaceFillingCurve2D {
   val cellwidth = (xmax - xmin) / resolution
   val cellheight = (ymax - ymin) / resolution
 
-  private final def mapToCol(x: Double) =
+  def mapToCol(x: Double) =
     ((x - xmin) / cellwidth).toInt
 
-  private final def mapToRow(y: Double) =
+  def mapToRow(y: Double) =
     ((ymax - y) / cellheight).toInt
 
-  private final def colToMap(col: Int) =
+  def colToMap(col: Int) =
     math.max(math.min(col * cellwidth + xmin + (cellwidth / 2), xmax), xmin)
 
-  private final def rowToMap(row: Int) =
+  def rowToMap(row: Int) =
     math.min(math.max(ymax - (row * cellheight) - (cellheight / 2), ymin), ymax)
 
 
@@ -49,17 +49,24 @@ class ZCurve2D(resolution: Int) extends SpaceFillingCurve2D {
     (colToMap(col), rowToMap(row))
   }
 
-  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double): Seq[(Long, Long)] = {
+  def bound(i: Long): (Double, Double, Double, Double) = {
+    val (col, row) = new Z2(i).decode
+    val x = colToMap(col)
+    val y = rowToMap(row)
+    (validateX(x - cellwidth), validateY(y-cellheight), validateX(x+cellwidth), validateY(y+cellheight))
+  }
+
+  def validateX(x: Double) = math.min(math.max(xmin, x), xmax)
+  def validateY(y: Double) = math.min(math.max(ymin, y), ymax)
+
+  def toRanges(xmin: Double, ymin: Double, xmax: Double, ymax: Double, maxRecurse: Int = 32): Seq[(Long, Long, Boolean)] = {
     val colMin = mapToCol(xmin)
     val rowMin = mapToRow(ymax)
-    println("Input: " + xmin + " ymin: " + ymin + " xmax: " + xmax + " ymax: " + ymax)
-    val min = Z2(rowMin, colMin)
-    println("minmapToCol: " + colMin + " minmapToRow: " + rowMin + " z: " + min.z)
+    val min = Z2(colMin, rowMin)
     val colMax = mapToCol(xmax)
     val rowMax = mapToRow(ymin)
-    val max = Z2(rowMin, colMin)
-    println("maxmapToCol: " + colMax + " maxmapToRow: " + rowMax + " z: " + max.z)
+    val max = Z2(colMax, rowMax)
 
-    Z2.zranges(min, max)
+    Z2.zranges(min, max, maxRecurse)
   }
 }

--- a/zorder/src/test/scala/org/locationtech/sfcurve/zorder/Z2IteratorSpec.scala
+++ b/zorder/src/test/scala/org/locationtech/sfcurve/zorder/Z2IteratorSpec.scala
@@ -26,13 +26,12 @@ class Z2IteratorSpec extends FunSpec with Matchers {
   }
 
   describe("ZCurve2D"){
+    it("creates a bounding box"){
+      val sfc = new ZCurve2D(2)
+      val range = sfc.toRanges(-178.123456, -86.398493, 179.3211113, 87.393483)
 
-      it("creates a bounding box"){
-          val sfc = new ZCurve2D(2)
-          val range = sfc.toRanges(-178.123456, -86.398493, 179.3211113, 87.393483)
-
-          range should have length 1
-      }
+      range should have length 1
+    }
   }
 }
 /**

--- a/zorder/src/test/scala/org/locationtech/sfcurve/zorder/ZCurve2DSpec.scala
+++ b/zorder/src/test/scala/org/locationtech/sfcurve/zorder/ZCurve2DSpec.scala
@@ -15,7 +15,7 @@ class ZCurve2DSpec extends FunSpec with Matchers {
       val ranges = sfc.toRanges(-80.0, 35.0, -75.0, 40.0, ZCurve2D.hints(maxRecurse = 12))
 
       ranges.length shouldBe 18
-      val (l, r, contains) = ranges.head
+      val (l, r, contains) = ranges.head.tuple
       l shouldBe 197616
       r shouldBe 197631
       contains shouldBe true

--- a/zorder/src/test/scala/org/locationtech/sfcurve/zorder/ZCurve2DSpec.scala
+++ b/zorder/src/test/scala/org/locationtech/sfcurve/zorder/ZCurve2DSpec.scala
@@ -9,6 +9,17 @@ class ZCurve2DSpec extends FunSpec with Matchers {
       val sfc = SpaceFillingCurves("zorder", Map(ZOrderSFCProvider.RESOLUTION_PARAM -> Int.box(100)))
       sfc.isInstanceOf[ZCurve2D] should equal(true)
     }
+
+    it("computes a covering set of ranges") {
+      val sfc = SpaceFillingCurves("zorder", Map(ZOrderSFCProvider.RESOLUTION_PARAM -> Int.box(1024)))
+      val ranges = sfc.toRanges(-80.0, 35.0, -75.0, 40.0, 12)
+
+      ranges.length shouldBe 18
+      val (l, r, contains) = ranges.head
+      l shouldBe 197616
+      r shouldBe 197631
+      contains shouldBe true
+    }
   }
 
 }

--- a/zorder/src/test/scala/org/locationtech/sfcurve/zorder/ZCurve2DSpec.scala
+++ b/zorder/src/test/scala/org/locationtech/sfcurve/zorder/ZCurve2DSpec.scala
@@ -12,7 +12,7 @@ class ZCurve2DSpec extends FunSpec with Matchers {
 
     it("computes a covering set of ranges") {
       val sfc = SpaceFillingCurves("zorder", Map(ZOrderSFCProvider.RESOLUTION_PARAM -> Int.box(1024)))
-      val ranges = sfc.toRanges(-80.0, 35.0, -75.0, 40.0, 12)
+      val ranges = sfc.toRanges(-80.0, 35.0, -75.0, 40.0, ZCurve2D.hints(maxRecurse = 12))
 
       ranges.length shouldBe 18
       val (l, r, contains) = ranges.head


### PR DESCRIPTION
- The range computation in Z2 had some copy/paste typos and was producing invalid
  ranges.  This commit fixes those issues.
- Exposes a boolean returned from the range decomposition that describes whether a
  given range is wholly contained in the query region or not.  This facilitates query
  planners that need to know whether a range is going to produce false positives or
  not and post-process accordingly.
